### PR TITLE
"card-columns" doesn't exists in new builds

### DIFF
--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -8,6 +8,11 @@
 
 /* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
+.card-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 2rem;
+}
 .card-columns .card:hover .card-img {
     opacity: 1;
     -webkit-transform-style: preserve-3d;
@@ -22,7 +27,6 @@ for details on configuring this project to bundle and minify static web assets. 
 .card-columns .card-img {
   height: 330px;
   vertical-align: bottom;
-  background-position: center; /* Center the image */
   background-repeat: no-repeat; /* Do not repeat the image */
   background-size: cover; /* Resize the background image to cover the entire container */
   opacity: .8;


### PR DESCRIPTION
inbuilt class = "card-columns" missing so all cards were appearing on single column. 
This changes fixes it using grid layout.